### PR TITLE
Add fetching of the latest reviews

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.spiget</groupId>
             <artifactId>parser</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.0.3-SNAPSHOT</version>
         </dependency>
 
         <!-- Logging -->

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -734,6 +734,44 @@ public class SpigetFetcher {
         }
     }
 
+    private void updateLatestResourceReviews() {
+        databaseClient.updateStatus("fetch.page.item.state", "reviews");
+        ResourceReviewItemParser reviewItemParser = new ResourceReviewItemParser();
+
+        try {
+            int pageCount = Paginator.parseDocumentPageCount(SpigetClient.get(SpigetClient.BASE_URL + "resources/reviews").getDocument());
+            int maxPage = Math.min(pageCount, config.get("fetch.resources.reviews.maxPage").getAsInt());
+            Paginator resourceReviewsPaginator = new Paginator(SpigetClient.BASE_URL + "resources/reviews?page=%s", maxPage, false);
+
+            for (Document reviewDocument : resourceReviewsPaginator) {
+                Element reviewList = reviewDocument.selectFirst("ol.reviews");
+                Elements reviewElements = reviewList.select("li.primaryContent.review");
+
+                for (Element reviewElement : reviewElements) {
+                    ResourceReview review = reviewItemParser.parse(reviewElement);
+                    Resource resource = databaseClient.getResource(review.getResource());
+
+                    if (resource.getReviews().contains(review)) {
+                        return; //We reached an review that's already in the db, so we finished fetching the latest ones.
+                    }
+
+                    resource.getReviews().add(review);
+                    review.setResource(review.getResource());
+
+                    Author databaseReviewAuthor = databaseClient.getAuthor(review.getAuthor().getId());
+                    if (databaseReviewAuthor == null) {// Only insert if the document doesn't exist, so we don't accidentally overwrite existing data
+                        databaseClient.insertAuthor(review.getAuthor());
+                    }
+
+                    databaseClient.updateOrInsertReview(resource, review);
+                }
+            }
+        } catch (Throwable throwable) {
+            Sentry.captureException(throwable);
+            log.error("Unexpected exception while parsing resource reviews", throwable);
+        }
+    }
+
     private void updateResourceDocumentation(@NotNull Resource resource) {
         databaseClient.updateStatus("fetch.page.item.state", "documentation");
         try {
@@ -795,6 +833,4 @@ public class SpigetFetcher {
             log.warn("Download for resource #" + resource.getId() + " failed", e);
         }
     }
-
-
 }

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -774,6 +774,8 @@ public class SpigetFetcher {
                     review.setResource(review.getResource());
 
                     float newAverage = resource.getRating().getAverage() + ((review.getRating().getAverage() - resource.getRating().getAverage()) / resource.getReviews().size());
+                    // round average to 1 decimal
+                    newAverage = Math.round(newAverage * 10) / 10f;
                     resource.setRating(new Rating(resource.getReviews().size(), newAverage));
 
                     Author databaseReviewAuthor = databaseClient.getAuthor(review.getAuthor().getId());

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -739,7 +739,6 @@ public class SpigetFetcher {
                     }
 
                     databaseClient.updateOrInsertReview(resource, review);
-                    databaseClient.updateResource(resource);
                 }
             }
         } catch (Throwable throwable) {

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -783,6 +783,8 @@ public class SpigetFetcher {
 
                     databaseClient.updateOrInsertReview(resource, review);
                     databaseClient.updateResource(resource);
+
+                    log.info("Updated resource #" + resource.getId() + " with new review #" + review.getId());
                 }
             }
         } catch (Throwable throwable) {

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -777,6 +777,7 @@ public class SpigetFetcher {
                     }
 
                     databaseClient.updateOrInsertReview(resource, review);
+                    databaseClient.updateResource(resource);
                 }
             }
         } catch (Throwable throwable) {

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -753,7 +753,7 @@ public class SpigetFetcher {
 
         try {
             int pageCount = Paginator.parseDocumentPageCount(SpigetClient.get(SpigetClient.BASE_URL + "resources/reviews").getDocument());
-            int maxPage = Math.min(pageCount, config.get("fetch.resources.reviews.maxPage").getAsInt());
+            int maxPage = Math.min(pageCount, config.get("fetch.resources.latestReviews.maxPage").getAsInt());
             Paginator resourceReviewsPaginator = new Paginator(SpigetClient.BASE_URL + "resources/reviews?page=%s", maxPage, false);
 
             for (Document reviewDocument : resourceReviewsPaginator) {

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -739,6 +739,7 @@ public class SpigetFetcher {
                     }
 
                     databaseClient.updateOrInsertReview(resource, review);
+                    databaseClient.updateResource(resource);
                 }
             }
         } catch (Throwable throwable) {

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -744,7 +744,7 @@ public class SpigetFetcher {
             Paginator resourceReviewsPaginator = new Paginator(SpigetClient.BASE_URL + "resources/reviews?page=%s", maxPage, false);
 
             for (Document reviewDocument : resourceReviewsPaginator) {
-                Element reviewList = reviewDocument.selectFirst("ol.reviews");
+                Element reviewList = reviewDocument.select("ol.reviews").first();
                 Elements reviewElements = reviewList.select("li.primaryContent.review");
 
                 for (Element reviewElement : reviewElements) {
@@ -752,7 +752,7 @@ public class SpigetFetcher {
                     Resource resource = databaseClient.getResource(review.getResource());
 
                     if (resource.getReviews().contains(review)) {
-                        return; //We reached an review that's already in the db, so we finished fetching the latest ones.
+                        return; //We reached a review that's already in the db, so we finished fetching the latest ones.
                     }
 
                     resource.getReviews().add(review);

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -28,6 +28,7 @@ import org.spiget.data.UpdateRequest;
 import org.spiget.data.author.Author;
 import org.spiget.data.author.ListedAuthor;
 import org.spiget.data.resource.ListedResource;
+import org.spiget.data.resource.Rating;
 import org.spiget.data.resource.Resource;
 import org.spiget.data.resource.ResourceReview;
 import org.spiget.data.resource.update.ResourceUpdate;
@@ -771,6 +772,9 @@ public class SpigetFetcher {
 
                     resource.getReviews().add(review);
                     review.setResource(review.getResource());
+
+                    float newAverage = resource.getRating().getAverage() + ((review.getRating().getAverage() - resource.getRating().getAverage()) / resource.getReviews().size());
+                    resource.setRating(new Rating(resource.getReviews().size(), newAverage));
 
                     Author databaseReviewAuthor = databaseClient.getAuthor(review.getAuthor().getId());
                     if (databaseReviewAuthor == null) {// Only insert if the document doesn't exist, so we don't accidentally overwrite existing data

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -368,6 +368,19 @@ public class SpigetFetcher {
         }
 
         try {
+            log.log(Level.INFO, "Running latest review update");
+            updateLatestResourceReviews();
+        } catch (Throwable throwable) {
+            Sentry.captureException(throwable);
+            log.log(Level.ERROR, "Latest review update exception", throwable);
+        }
+
+        try {
+            Thread.sleep(2000);
+        } catch (Exception ignored) {
+        }
+
+        try {
             log.log(Level.INFO, "Running update request fetch");
             int maxResourceRequest = config.get("resourceRequest.max").getAsInt();
             Set<UpdateRequest> updateRequests = databaseClient.getUpdateRequests(maxResourceRequest);

--- a/src/main/java/org/spiget/fetcher/SpigetFetcher.java
+++ b/src/main/java/org/spiget/fetcher/SpigetFetcher.java
@@ -764,7 +764,8 @@ public class SpigetFetcher {
                     ResourceReview review = reviewItemParser.parse(reviewElement);
                     Resource resource = databaseClient.getResource(review.getResource());
 
-                    if (resource.getReviews().contains(review)) {
+                    boolean reviewExists = resource.getReviews().stream().anyMatch(r -> r.getId() == review.getId());
+                    if (reviewExists) {
                         return; //We reached a review that's already in the db, so we finished fetching the latest ones.
                     }
 


### PR DESCRIPTION
The fetcher will automatically stop once it reaches an review that's already stored, so it probably(almost sure, or someone has to be spamming reviews) only fetches one page each time. Still pagination, just in case. I do not know how you implemented timers and I can't find them too. Can you add an timer to run this method every 30 minutes or something like that? Thanks for looking into this PR!